### PR TITLE
Add business detail links to alerts and improve data fetching

### DIFF
--- a/backend/app/routers/alerts.py
+++ b/backend/app/routers/alerts.py
@@ -16,12 +16,13 @@ _SCHEDULED_TYPES = {"committee_scheduled", "debate_scheduled"}
 
 
 def _attach_business_titles(alerts: list[Alert], user_id: int, db: Session) -> list[dict]:
-    """Look up business titles for a list of alerts and return dicts with business_title."""
+    """Look up business titles and IDs for a list of alerts and return dicts."""
     biz_numbers = list({a.business_number for a in alerts})
     title_map: dict[str, str] = {}
+    id_map: dict[str, int] = {}
     if biz_numbers:
         rows = (
-            db.query(TrackedBusiness.business_number, TrackedBusiness.title)
+            db.query(TrackedBusiness.business_number, TrackedBusiness.title, TrackedBusiness.id)
             .filter(
                 TrackedBusiness.user_id == user_id,
                 TrackedBusiness.business_number.in_(biz_numbers),
@@ -30,6 +31,7 @@ def _attach_business_titles(alerts: list[Alert], user_id: int, db: Session) -> l
         )
         for row in rows:
             title_map[row.business_number] = row.title or ""
+            id_map[row.business_number] = row.id
 
     result = []
     for a in alerts:
@@ -37,6 +39,7 @@ def _attach_business_titles(alerts: list[Alert], user_id: int, db: Session) -> l
             "id": a.id,
             "business_number": a.business_number,
             "business_title": title_map.get(a.business_number, ""),
+            "business_id": id_map.get(a.business_number),
             "alert_type": a.alert_type,
             "message": a.message,
             "event_date": a.event_date,

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -99,6 +99,7 @@ class AlertOut(BaseModel):
     id: int
     business_number: str
     business_title: Optional[str] = None
+    business_id: Optional[int] = None
     alert_type: str
     message: str
     event_date: Optional[datetime] = None

--- a/backend/app/services/parliament_api.py
+++ b/backend/app/services/parliament_api.py
@@ -326,13 +326,15 @@ async def fetch_new_businesses(since_date: str) -> list[dict]:
         "$filter": f"SubmissionDate ge datetime'{since_date}T00:00:00' and Language eq 'DE'",
         "$format": "json",
         "$orderby": "SubmissionDate desc",
-        "$top": "100",
+        "$top": "500",
     }
     data = await _get(url, params)
     if not data:
         return []
 
     results = data.get("d", {}).get("results", []) if isinstance(data.get("d"), dict) else []
+    if not results:
+        results = data.get("d", []) if isinstance(data.get("d"), list) else []
     out = []
     for item in results:
         nr = item.get("BusinessShortNumber", "")

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -158,7 +158,7 @@ async def fetch_monitoring_candidates():
     """Fetch new businesses for monitoring (runs daily at 07:00)."""
     db: Session = SessionLocal()
     try:
-        since = (datetime.utcnow() - timedelta(days=2)).strftime("%Y-%m-%d")
+        since = (datetime.utcnow() - timedelta(days=90)).strftime("%Y-%m-%d")
         new_businesses = await fetch_new_businesses(since)
         added = 0
 

--- a/frontend/src/components/AlertItem.jsx
+++ b/frontend/src/components/AlertItem.jsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { markAlertRead } from "../api/client";
 
 const TYPE_LABELS = {
@@ -30,12 +31,25 @@ export default function AlertItem({ alert, onUpdated }) {
             <span className="text-xs font-medium px-2 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300">
               {TYPE_LABELS[alert.alert_type] || alert.alert_type}
             </span>
-            <span className="text-xs text-gray-500">
-              {alert.business_number}
-              {alert.business_title && (
-                <span className="ml-1 text-gray-400">– {alert.business_title}</span>
-              )}
-            </span>
+            {alert.business_id ? (
+              <Link
+                to={`/business/${alert.business_id}`}
+                className="text-xs text-swiss-red hover:underline"
+                onClick={(e) => e.stopPropagation()}
+              >
+                {alert.business_number}
+                {alert.business_title && (
+                  <span className="ml-1 text-gray-400">– {alert.business_title}</span>
+                )}
+              </Link>
+            ) : (
+              <span className="text-xs text-gray-500">
+                {alert.business_number}
+                {alert.business_title && (
+                  <span className="ml-1 text-gray-400">– {alert.business_title}</span>
+                )}
+              </span>
+            )}
             {!alert.is_read && (
               <span className="w-2 h-2 rounded-full bg-swiss-red flex-shrink-0" />
             )}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -28,8 +28,8 @@ export default function Dashboard() {
   const [businesses, setBusinesses] = useState([]);
   const [unreadCount, setUnreadCount] = useState(0);
   const [loading, setLoading] = useState(true);
-  const [sortKey, setSortKey] = useState("submission_date");
-  const [sortDir, setSortDir] = useState("desc");
+  const [sortKey, setSortKey] = useState("priority");
+  const [sortDir, setSortDir] = useState("asc");
 
   const load = async () => {
     try {


### PR DESCRIPTION
## Summary
This PR enhances the alert system by making business references clickable links to their detail pages, while also improving the backend's data fetching and sorting capabilities.

## Key Changes

**Frontend:**
- Modified `AlertItem.jsx` to render business numbers as clickable links (when `business_id` is available) that navigate to `/business/{business_id}`
- Links are styled with the Swiss red color and include hover underline effect
- Fallback to plain text display when `business_id` is not available
- Added `stopPropagation()` to prevent triggering parent alert item click handlers

**Backend:**
- Updated `_attach_business_titles()` in `alerts.py` to fetch and include `business_id` alongside business titles
- Added `business_id` field to the `AlertOut` schema for API responses
- Increased the Parliament API fetch limit from 100 to 500 results in `parliament_api.py`
- Added fallback logic in `parliament_api.py` to handle alternative response formats from the Parliament API
- Extended the monitoring candidate fetch window from 2 days to 90 days in `scheduler.py` to capture more historical data

**Dashboard:**
- Changed default sort order from `submission_date` (descending) to `priority` (ascending) for better alert prioritization

## Implementation Details
- The business link feature gracefully degrades to plain text when `business_id` is unavailable
- The Parliament API changes improve robustness by handling both dict and list response formats
- The extended 90-day lookback window allows the system to monitor a broader range of recently submitted businesses

https://claude.ai/code/session_01KpuJQMgJncHLrPCfVP2GTu